### PR TITLE
Compute seabed stress at CD-grid locations

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -502,13 +502,40 @@
          !$OMP PARALLEL DO PRIVATE(iblk)
          do iblk = 1, nblocks
 
+            select case (trim(grid_system))
+            case('B')
+
+               if ( seabed_stress_method == 'LKD' ) then
+
+                  call seabed_stress_factor_LKD (nx_block,         ny_block,       &
+                                                 icellu  (iblk),                   &
+                                                 indxui(:,iblk),   indxuj(:,iblk), &
+                                                 vice(:,:,iblk),   aice(:,:,iblk), &
+                                                 hwater(:,:,iblk), Tbu(:,:,iblk))
+
+               elseif ( seabed_stress_method == 'probabilistic' ) then
+
+                  call seabed_stress_factor_prob (nx_block,         ny_block,                   &
+                                                  icellt(iblk), indxti(:,iblk), indxtj(:,iblk), &
+                                                  icellu(iblk), indxui(:,iblk), indxuj(:,iblk), &
+                                                  aicen(:,:,:,iblk), vicen(:,:,:,iblk),         &
+                                                  hwater(:,:,iblk), Tbu(:,:,iblk))
+               endif
+
+         case('CD')
+
             if ( seabed_stress_method == 'LKD' ) then
 
                call seabed_stress_factor_LKD (nx_block,         ny_block,       &
-                                              icellu  (iblk),                   &
-                                              indxui(:,iblk),   indxuj(:,iblk), &
+                                              icelle  (iblk),                   &
+                                              indxei(:,iblk),   indxej(:,iblk), &
                                               vice(:,:,iblk),   aice(:,:,iblk), &
-                                              hwater(:,:,iblk), Tbu(:,:,iblk))
+                                              hwater(:,:,iblk), TbE(:,:,iblk))
+               call seabed_stress_factor_LKD (nx_block,         ny_block,       &
+                                              icelln  (iblk),                   &
+                                              indxni(:,iblk),   indxnj(:,iblk), &
+                                              vice(:,:,iblk),   aice(:,:,iblk), &
+                                              hwater(:,:,iblk), TbN(:,:,iblk))
 
             elseif ( seabed_stress_method == 'probabilistic' ) then
 
@@ -516,8 +543,13 @@
                                                icellt(iblk), indxti(:,iblk), indxtj(:,iblk), &
                                                icellu(iblk), indxui(:,iblk), indxuj(:,iblk), &
                                                aicen(:,:,:,iblk), vicen(:,:,:,iblk),         &
-                                               hwater(:,:,iblk), Tbu(:,:,iblk))
+                                               hwater(:,:,iblk), Tbu(:,:,iblk),              &
+                                               TbE(:,:,iblk),    TbN(:,:,iblk),              &
+                                               icelle(iblk), indxei(:,iblk), indxej(:,iblk), &
+                                               icelln(iblk), indxni(:,iblk), indxnj(:,iblk)  )
             endif
+
+         end select
          
          enddo
        !$OMP END PARALLEL DO

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -957,7 +957,7 @@
       integer (kind=int_kind) :: &
          i, j, ij
 
-      character(len=*), parameter :: subname = '(seabed1_stress_coeff)'
+      character(len=*), parameter :: subname = '(seabed_stress_factor_LKD)'
       
       do ij = 1, icellu
          i = indxui(ij)

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -930,11 +930,12 @@
                                            icellu,                     &
                                            indxui,   indxuj,           &
                                            vice,     aice,             &
-                                           hwater,   Tbu)
+                                           hwater,   Tbu,              &
+                                           grid_location)
 
       integer (kind=int_kind), intent(in) :: &
          nx_block, ny_block, &  ! block dimensions
-         icellu                 ! no. of cells where icetmask = 1
+         icellu                 ! no. of cells where ice[uen]mask = 1
 
       integer (kind=int_kind), dimension (nx_block*ny_block), intent(in) :: &
          indxui   , & ! compressed index in i-direction
@@ -946,19 +947,32 @@
          hwater      ! water depth at tracer location (m)
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(inout) :: &
-         Tbu         ! seabed stress factor (N/m^2)
+         Tbu         ! seabed stress factor at 'grid_location' (N/m^2)
+
+      character(len=*), optional, intent(inout) :: &
+         grid_location    ! grid location (U, E, N), U assumed if not present
 
       real (kind=dbl_kind) :: &
-         au,  & ! concentration of ice at u location
-         hu,  & ! volume per unit area of ice at u location (mean thickness, m)
-         hwu, & ! water depth at u location (m)
-         hcu    ! critical thickness at u location (m)
+         au,  & ! concentration of ice at 'grid_location' 
+         hu,  & ! volume per unit area of ice at 'grid_location' (mean thickness, m)
+         hwu, & ! water depth at 'grid_location' (m)
+         hcu    ! critical thickness at 'grid_location' (m)
 
       integer (kind=int_kind) :: &
          i, j, ij
 
+      character(len=char_len) :: &
+         l_grid_location    ! local version of 'grid_location'
+
       character(len=*), parameter :: subname = '(seabed_stress_factor_LKD)'
       
+      ! Assume U location (NE corner) if grid_location not present
+      if (.not. (present(grid_location))) then
+         l_grid_location = 'U'
+      else
+         l_grid_location = grid_location
+      endif
+
       do ij = 1, icellu
          i = indxui(ij)
          j = indxuj(ij)

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -933,6 +933,8 @@
                                            hwater,   Tbu,              &
                                            grid_location)
 
+      use ice_grid, only: grid_neighbor_min, grid_neighbor_max
+
       integer (kind=int_kind), intent(in) :: &
          nx_block, ny_block, &  ! block dimensions
          icellu                 ! no. of cells where ice[uen]mask = 1
@@ -977,14 +979,14 @@
          i = indxui(ij)
          j = indxuj(ij)
 
-         ! convert quantities to u-location
+         ! convert quantities to grid_location
          
-         hwu = min(hwater(i,j),hwater(i+1,j),hwater(i,j+1),hwater(i+1,j+1))
+         hwu = grid_neighbor_min(hwater, i, j, l_grid_location)
 
          if (hwu < threshold_hw) then
          
-            au  = max(aice(i,j),aice(i+1,j),aice(i,j+1),aice(i+1,j+1))
-            hu  = max(vice(i,j),vice(i+1,j),vice(i,j+1),vice(i+1,j+1))
+            au  = grid_neighbor_max(aice, i, j, l_grid_location)
+            hu  = grid_neighbor_max(vice, i, j, l_grid_location)
 
             ! 1- calculate critical thickness
             hcu = au * hwu / k1

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -1084,7 +1084,7 @@
       real (kind=dbl_kind) :: atot, x_kmax
       real (kind=dbl_kind) :: cut, rhoi, rhow, gravit, pi, puny
 
-      character(len=*), parameter :: subname = '(seabed2_stress_coeff)'
+      character(len=*), parameter :: subname = '(seabed_stress_factor_prob)'
 
       call icepack_query_parameters(rhow_out=rhow, rhoi_out=rhoi)
       call icepack_query_parameters(gravit_out=gravit)

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -46,7 +46,7 @@
       implicit none
       private
       public :: init_grid1, init_grid2, grid_average_X2Y, &
-                alloc_grid, makemask
+                alloc_grid, makemask, grid_neighbor_min, grid_neighbor_max
 
       character (len=char_len_long), public :: &
          grid_format  , & ! file format ('bin'=binary or 'nc'=netcdf)
@@ -2802,6 +2802,68 @@
          end select
 
       end subroutine grid_average_X2YF
+
+!=======================================================================
+! Compute the minimum of adjacent values of a field at specific indices,
+! depending on the grid location (U, E, N)
+!
+      real(kind=dbl_kind) function grid_neighbor_min(field, i, j, grid_location) result(mini)
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
+         field    ! field defined at T point
+
+      integer (kind=int_kind), intent(in) :: &
+         i, j
+
+      character(len=*), intent(in) :: &
+         grid_location ! grid location at which to compute the minumum (U, E, N)
+
+      character(len=*), parameter :: subname = '(grid_neighbor_min)'
+
+      select case (trim(grid_location))
+         case('U')
+            mini = min(field(i,j), field(i+1,j), field(i,j+1), field(i+1,j+1))
+         case('E')
+            mini = min(field(i,j), field(i+1,j))
+         case('N')
+            mini = min(field(i,j), field(i,j+1))
+         case default
+            call abort_ice(subname // ' unkwown grid_location: ' // grid_location)
+      end select
+
+      end function grid_neighbor_min
+
+
+!=======================================================================
+! Compute the maximum of adjacent values of a field at specific indices,
+! depending on the grid location (U, E, N)
+!
+      real(kind=dbl_kind) function grid_neighbor_max(field, i, j, grid_location) result(maxi)
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
+         field    ! field defined at T point
+
+      integer (kind=int_kind), intent(in) :: &
+         i, j
+
+      character(len=*), intent(in) :: &
+         grid_location ! grid location at which to compute the maximum (U, E, N)
+
+
+      character(len=*), parameter :: subname = '(grid_neighbor_max)'
+
+      select case (trim(grid_location))
+         case('U')
+            maxi = max(field(i,j), field(i+1,j), field(i,j+1), field(i+1,j+1))
+         case('E')
+            maxi = max(field(i,j), field(i+1,j))
+         case('N')
+            maxi = max(field(i,j), field(i,j+1))
+         case default
+            call abort_ice(subname // ' unkwown grid_location: ' // grid_location)
+      end select
+
+      end function grid_neighbor_max
 
 !=======================================================================
 ! The following code is used for obtaining the coordinates of the grid


### PR DESCRIPTION
Here are the changes for the seabed stress factor. I used a slightly different approach for the probabilistic method, as I thought it made more sense. Details of my rationale are in the commit messages, which I copy below for ease of access:

~~~
commit 7f8b856a0bb9fcf7407179d0ea56193de96fd388
Author: Philippe Blain <philippe.blain@canada.ca>
Date:   6 hours ago

    ice_dyn_shared: fix subname for 'seabed_stress_factor_LKD'

commit 20dc8e884d4f6e1f9859899f029d0f852ee311cf
Author: Philippe Blain <philippe.blain@canada.ca>
Date:   5 hours ago

    ice_dyn_shared: add optional 'grid_location' argument to seabed_stress_factor_LKD
    
    In subsequent commits we want to compute the seabed stress factor
    'Tb' not only at the U point (NE corner) but also at the E (center of
    E face) and N (center of N face) points.
    
    In order to dispatch the computation in this subroutine to different
    code paths depending on the grid location (U, N or E), add an optional
    argument 'grid_location' that can be used to indicate at which point we
    want the factor to be computed. Default it to the 'U' point for
    backwards compatibility, such that the existing calls do not have to be
    changed.
    
    Note that we need an additional 'l_grid_location' variable to set the
    default value, as the Fortran standard does not allow setting the value
    of an optional argument if it is not present.
    
    Note also that 'icellu' was incorrectly referencing 'icetmask'. Fix that
    by generalizing the description.

commit ecfe7286bab91c55e0859ffc87bbd41801825c0e
Author: Philippe Blain <philippe.blain@canada.ca>
Date:   2 hours ago

    ice_grid: add 'grid_neighbor_{min,max}' functions
    
    Add functions 'grid_neighbor_min' and 'grid_neighbor_max', used to
    compute the minimum/maximum of neighboring T-point values of a field at
    the U, E or N location.

commit d15b6e1285e3ff1d7207645625c18ebdedcd648d
Author: Philippe Blain <philippe.blain@canada.ca>
Date:   80 minutes ago

    ice_dyn_shared (seabed_stress_factor_LKD): use 'grid_neighbor_{min,max}'
    
    Use the 'grid_neighbor_{min,max}' subroutines introduced in the
    preceding commit to compute the min and max of neighbor values of
    hwater, aice and vice at 'grid_location'. This generalizes the
    subroutine for the CD-grid. A subsequent commit will call it twice to
    compute the seabed stress factor at the E and N locations.

commit 40d8aa28cf1f3cae23034aadcf6bf3e9c5963b37
Author: Philippe Blain <philippe.blain@canada.ca>
Date:   6 hours ago

    ice_dyn_shared: fix subname for 'seabed_stress_factor_prob'

commit 5ea414163598c441b01b0be34fa61322ee3f1f20
Author: Philippe Blain <philippe.blain@canada.ca>
Date:   31 minutes ago

    ice_dyn_shared: add optional CD-grid arguments to 'seabed_stress_factor_prob'
    
    In contrast to 'seabed_stress_factor_LKD', in
    'seabed_stress_factor_prob' the seabed stress factor is computed at the
    T location and only transfered to the U location at the end of the
    subroutine. So for efficiency it does not make sense to call that
    subroutine twice for computing the factor at the E and N locations.
    
    Instead, add optional arguments for 'TbE' and 'TbN', as well as the
    corresponding indices paraphernalia, and compute the factor at the E and
    N location at the end of the subroutine depending on 'grid_system' and
    the presence of the optional arguments.
    
    Use 'grid_neighbor_max' to abstract away the operation of finding the
    maximum value of neighboring cells.

commit 22812b5f98951bbba402fe39bab592d0fb1306e5
Author: Philippe Blain <philippe.blain@canada.ca>
Date:   9 minutes ago

    ice_dyn_evp: compute seabed stress factor at CD-grid locations
    
    Leverage the changes in the previous commits to compute the seabed
    stress factor at the E and N locations if grid_system == 'CD'.
    
    For seabed_stress_method == 'LKD', simply call seabed_stress_factor_LKD
    twice, once for each of the E and N locations.
    
    For seabed_stress_method == 'probabilistic', call
    seabed_stress_factor_prob with the additional arguments for the E and N
    locations.

~~~