### PR TITLE
Remove read of CD stresses on restart for initial testing

### DIFF
--- a/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
+++ b/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
@@ -381,6 +381,9 @@
       call read_restart_field(nu_restart,0,stress12_4,'ruf8', &
            'stress12_4',1,diag,field_loc_center,field_type_scalar) ! stress12_4
 
+! tcraig, comment these out now to allow restarts from B grid file
+! this will affect exact restart when we get to that point
+#if (1 == 0)
       if (grid_system == 'CD') then
          call read_restart_field(nu_restart,0,stresspT,'ruf8', &
             'stresspT' ,1,diag,field_loc_center,field_type_scalar) ! stresspT
@@ -395,6 +398,7 @@
          call read_restart_field(nu_restart,0,stress12U,'ruf8', &
             'stress12U',1,diag,field_loc_center,field_type_scalar) ! stress12U
       endif
+#endif
 
       if (trim(grid_type) == 'tripole') then
          call ice_HaloUpdate_stress(stressp_1, stressp_3, halo_info, &


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
   ifdef out the CD stress restart read to allow usage of B grid restart files for initial CD testing
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    Tested gx3 CD case with and without mods, fails without mod, runs with mod.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:
