### PR TITLE
Initialize uvel, vvel at every substep

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -646,6 +646,13 @@
 
          do ksub = 1,ndte        ! subcycling
 
+         ! shift velocity components from CD grid locations (N, E) to B grid location (U) for stress_U
+
+            if (grid_system == 'CD') then
+                call grid_average_X2Y('E2US',uvelE,uvel)
+                call grid_average_X2Y('N2US',vvelN,vvel)
+            endif
+
          !-----------------------------------------------------------------
          ! stress tensor equation, total surface stress
          !-----------------------------------------------------------------


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Added lines to initialize U grid velocities at beginning at substep.
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Builds and runs with grid_system = 'CD'. Still blows up in box_islands case.
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
This will change answers as uvel/vvel are used in stress_U and were not updated.