### PR TITLE
Turn off OMP around seabed stress, causes aborts on cheyenne with pgi

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -400,7 +400,8 @@
       
       if (seabed_stress) then
 
-       !$OMP PARALLEL DO PRIVATE(iblk)
+       ! tcraig, evp omp causes abort on cheyenne with pgi, turn off here too
+       !$TCXOMP PARALLEL DO PRIVATE(iblk)
        do iblk = 1, nblocks
           
           if ( seabed_stress_method == 'LKD' ) then
@@ -421,7 +422,7 @@
           endif
 
        enddo
-       !$OMP END PARALLEL DO 
+       !$TCXOMP END PARALLEL DO 
       endif
       
       do ksub = 1,ndte        ! subcycling

--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -552,7 +552,8 @@
       
       if (seabed_stress) then
 
-         !$OMP PARALLEL DO PRIVATE(iblk)
+         ! tcraig, causes abort with pgi compiler on cheyenne
+         !$TCXOMP PARALLEL DO PRIVATE(iblk)
          do iblk = 1, nblocks
 
             select case (trim(grid_system))
@@ -605,7 +606,7 @@
          end select
          
          enddo
-       !$OMP END PARALLEL DO
+       !$TCXOMP END PARALLEL DO
       endif
 
       call ice_timer_start(timer_evp_2d)

--- a/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
@@ -446,7 +446,8 @@
       
       if (seabed_stress) then
 
-         !$OMP PARALLEL DO PRIVATE(iblk)
+         ! tcraig, evp omp causes abort on cheyenne with pgi, turn off here too
+         !$TCXOMP PARALLEL DO PRIVATE(iblk)
          do iblk = 1, nblocks
 
             if ( seabed_stress_method == 'LKD' ) then
@@ -467,7 +468,7 @@
             endif
 
          enddo
-         !$OMP END PARALLEL DO
+         !$TCXOMP END PARALLEL DO
       endif
       
       !-----------------------------------------------------------------


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Turn off OMP around seabed stress, causes aborts on cheyenne with pgi.  
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    bit-for-bit, fixes the errors showing up in pgi suites on this branch.  New results are here, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#380e34077567fdae16cbae143b16a03d7557ec64
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:

This is relatively new with the cgrid implementation.  Will need to eventually time/debug/fix all the "turned off" OMP.  See https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#9e6e8f330efbadb7d1613862e32c3b8c5cebfa8b to see the 14 failed pgi tests.  Latest results are here, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#380e34077567fdae16cbae143b16a03d7557ec64

This is part of an effort to keep the B configuration running and bit-for-bit on the full test suite on the cgridDEV branch.