### PR TITLE
Fix box2001 forcing, restart fields on land, bathymetry default value, omp_suite

### DIFF
--- a/cicecore/cicedynB/general/ice_forcing.F90
+++ b/cicecore/cicedynB/general/ice_forcing.F90
@@ -682,7 +682,7 @@
       !$OMP PARALLEL DO PRIVATE(iblk,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
 
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -2438,7 +2438,7 @@
         enddo
 
       ! AOMIP
-        this_block = get_block(blocks_ice(iblk),iblk)         
+        this_block = get_block(blocks_ice(iblk),iblk)
         ilo = this_block%ilo
         ihi = this_block%ihi
         jlo = this_block%jlo
@@ -3480,7 +3480,7 @@
         enddo
 
       ! AOMIP
-      this_block = get_block(blocks_ice(iblk),iblk)         
+      this_block = get_block(blocks_ice(iblk),iblk)
       ilo = this_block%ilo
       ihi = this_block%ihi
       jlo = this_block%jlo
@@ -5313,10 +5313,10 @@
 ! these are defined at the u point
 ! authors: Elizabeth Hunke, LANL
 
-      use ice_domain, only: nblocks
+      use ice_domain, only: nblocks, blocks_ice
       use ice_domain_size, only: max_blocks
       use ice_calendar, only: timesecs
-      use ice_blocks, only: nx_block, ny_block, nghost
+      use ice_blocks, only: block, get_block, nx_block, ny_block, nghost
       use ice_flux, only: uatm, vatm, wind, rhoa, strax, stray
       use ice_state, only: aice
 
@@ -5325,8 +5325,15 @@
       integer (kind=int_kind) :: &
          iblk, i,j           ! loop indices
 
+      integer (kind=int_kind) :: &
+         iglob(nx_block), & ! global indices
+         jglob(ny_block)    ! global indices
+
+      type (block) :: &
+         this_block           ! block information for current block
+
       real (kind=dbl_kind) :: &
-          secday, pi , puny, period, pi2, tau
+         secday, pi , puny, period, pi2, tau
 
       character(len=*), parameter :: subname = '(box2001_data_atm)'
 
@@ -5341,6 +5348,10 @@
          do j = 1, ny_block   
          do i = 1, nx_block   
 
+         this_block = get_block(blocks_ice(iblk),iblk)
+         iglob = this_block%i_glob
+         jglob = this_block%j_glob
+
 !tcraig, move to box2001_data_ocn
 !         ! ocean current
 !         ! constant in time, could be initialized in ice_flux.F90
@@ -5354,14 +5365,14 @@
 
          ! wind components
          uatm(i,j,iblk) = c5 + (sin(pi2*timesecs/period)-c3) &
-                              * sin(pi2*real(i-nghost, kind=dbl_kind)  &
+                              * sin(pi2*real(iglob(i), kind=dbl_kind)  &
                                        /real(nx_global,kind=dbl_kind)) &
-                              * sin(pi *real(j-nghost, kind=dbl_kind)  &
+                              * sin(pi *real(jglob(j), kind=dbl_kind)  &
                                        /real(ny_global,kind=dbl_kind))
          vatm(i,j,iblk) = c5 + (sin(pi2*timesecs/period)-c3) &
-                              * sin(pi *real(i-nghost, kind=dbl_kind)  &
+                              * sin(pi *real(iglob(i), kind=dbl_kind)  &
                                        /real(nx_global,kind=dbl_kind)) &
-                              * sin(pi2*real(j-nghost, kind=dbl_kind)  &
+                              * sin(pi2*real(jglob(j), kind=dbl_kind)  &
                                        /real(ny_global,kind=dbl_kind))
          ! wind stress
          wind(i,j,iblk) = sqrt(uatm(i,j,iblk)**2 + vatm(i,j,iblk)**2)
@@ -5408,10 +5419,10 @@
 ! these are defined at the u point
 ! authors: Elizabeth Hunke, LANL
 
-      use ice_domain, only: nblocks
+      use ice_domain, only: nblocks, blocks_ice
       use ice_domain_size, only: max_blocks
       use ice_calendar, only: timesecs
-      use ice_blocks, only: nx_block, ny_block, nghost
+      use ice_blocks, only: block, get_block, nx_block, ny_block, nghost
       use ice_flux, only: uocn, vocn
       use ice_grid, only: uvm
 
@@ -5420,8 +5431,15 @@
       integer (kind=int_kind) :: &
          iblk, i,j           ! loop indices
 
+      integer (kind=int_kind) :: &
+         iglob(nx_block), & ! global indices
+         jglob(ny_block)    ! global indices
+
+      type (block) :: &
+         this_block           ! block information for current block
+
       real (kind=dbl_kind) :: &
-          secday, pi , puny, period, pi2, tau
+         secday, pi , puny, period, pi2, tau
 
       character(len=*), parameter :: subname = '(box2001_data_ocn)'
 
@@ -5431,12 +5449,16 @@
          do j = 1, ny_block   
          do i = 1, nx_block   
 
+         this_block = get_block(blocks_ice(iblk),iblk)
+         iglob = this_block%i_glob
+         jglob = this_block%j_glob
+
          ! ocean current
          ! constant in time, could be initialized in ice_flux.F90
-         uocn(i,j,iblk) =  p2*real(j-nghost, kind=dbl_kind) &
-                            / real(nx_global,kind=dbl_kind) - p1
-         vocn(i,j,iblk) = -p2*real(i-nghost, kind=dbl_kind) &
-                            / real(ny_global,kind=dbl_kind) + p1
+         uocn(i,j,iblk) =  p2*real(jglob(j), kind=dbl_kind) &
+                            / real(ny_global,kind=dbl_kind) - p1
+         vocn(i,j,iblk) = -p2*real(iglob(i), kind=dbl_kind) &
+                            / real(nx_global,kind=dbl_kind) + p1
 
          uocn(i,j,iblk) = uocn(i,j,iblk) * uvm(i,j,iblk)
          vocn(i,j,iblk) = vocn(i,j,iblk) * uvm(i,j,iblk)

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -4228,6 +4228,7 @@
             depth(k) = depth(k-1) + thick(k)
          enddo
 
+         bathymetry = 0._dbl_kind
          do iblk = 1, nblocks
             do j = 1, ny_block
             do i = 1, nx_block

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -4177,6 +4177,8 @@
 
       subroutine get_bathymetry
 
+      use ice_constants, only: c0
+
       integer (kind=int_kind) :: &
          i, j, k, iblk      ! loop indices
 
@@ -4228,7 +4230,7 @@
             depth(k) = depth(k-1) + thick(k)
          enddo
 
-         bathymetry = 0._dbl_kind
+         bathymetry = c0
          do iblk = 1, nblocks
             do j = 1, ny_block
             do i = 1, nx_block

--- a/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
+++ b/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
@@ -62,7 +62,7 @@
           stresspT, stressmT, stress12T, &
           stresspU, stressmU, stress12U 
       use ice_flux, only: coszen
-      use ice_grid, only: grid_ice
+      use ice_grid, only: grid_ice, tmask
       use ice_state, only: aicen, vicen, vsnon, trcrn, uvel, vvel, &
                            uvelE, vvelE, uvelN, vvelN
 
@@ -96,6 +96,20 @@
       endif
 
       diag = .true.
+
+      !-----------------------------------------------------------------
+      ! Zero out tracers over land
+      !-----------------------------------------------------------------
+
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
+      do iblk = 1, nblocks
+         do j = 1, ny_block
+         do i = 1, nx_block
+            if (.not. tmask(i,j,iblk)) trcrn(i,j,:,:,iblk) = c0
+         enddo
+         enddo
+      enddo
+      !$OMP END PARALLEL DO
 
       !-----------------------------------------------------------------
       ! state variables

--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
@@ -788,8 +788,7 @@
                   amax = global_maxval(work(:,:,n,:),distrb_info)
                   asum = global_sum(work(:,:,n,:), distrb_info, field_loc_center)
                   if (my_task == master_task) then
-                     write(nu_diag,*) ' min and max =', amin, amax
-                     write(nu_diag,*) ' sum =',asum
+                     write(nu_diag,*) ' min, max, sum =', amin, amax, asum, trim(vname)
                   endif
                enddo
             else
@@ -797,9 +796,7 @@
                amax = global_maxval(work(:,:,1,:),distrb_info)
                asum = global_sum(work(:,:,1,:), distrb_info, field_loc_center)
                if (my_task == master_task) then
-                  write(nu_diag,*) ' min and max =', amin, amax
-                  write(nu_diag,*) ' sum =',asum
-                  write(nu_diag,*) ''
+                  write(nu_diag,*) ' min, max, sum =', amin, amax, asum, trim(vname)
                endif
             endif
          
@@ -878,8 +875,7 @@
                   amax = global_maxval(work(:,:,n,:),distrb_info)
                   asum = global_sum(work(:,:,n,:), distrb_info, field_loc_center)
                   if (my_task == master_task) then
-                     write(nu_diag,*) ' min and max =', amin, amax
-                     write(nu_diag,*) ' sum =',asum
+                     write(nu_diag,*) ' min, max, sum =', amin, amax, asum, trim(vname)
                   endif
                enddo
             else
@@ -887,8 +883,7 @@
                amax = global_maxval(work(:,:,1,:),distrb_info)
                asum = global_sum(work(:,:,1,:), distrb_info, field_loc_center)
                if (my_task == master_task) then
-                  write(nu_diag,*) ' min and max =', amin, amax
-                  write(nu_diag,*) ' sum =',asum
+                  write(nu_diag,*) ' min, max, sum =', amin, amax, asum, trim(vname)
                endif
             endif
          endif

--- a/cicecore/shared/ice_restart_column.F90
+++ b/cicecore/shared/ice_restart_column.F90
@@ -1065,9 +1065,9 @@
       ! Zero out tracers over land
       !-----------------------------------------------------------------
 
-      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo

--- a/cicecore/shared/ice_restart_column.F90
+++ b/cicecore/shared/ice_restart_column.F90
@@ -913,6 +913,7 @@
       use ice_blocks, only: block, get_block
       use ice_domain, only: nblocks, blocks_ice
       use ice_fileunits, only: nu_dump_hbrine
+      use ice_grid, only: tmask
       use ice_state, only: trcrn
       use ice_restart,only: write_restart_field
 
@@ -949,7 +950,8 @@
         do j = jlo, jhi
         do i = ilo, ihi  
            do n = 1, ncat
-              if (first_ice     (i,j,n,iblk)) then
+              ! zero out first_ice over land
+              if (tmask(i,j,iblk) .and. first_ice (i,j,n,iblk)) then
                   first_ice_real(i,j,n,iblk) = c1
               else
                   first_ice_real(i,j,n,iblk) = c0
@@ -983,6 +985,7 @@
       use ice_fileunits, only: nu_dump_bgc
       use ice_flux_bgc, only: nit, amm, sil, dmsp, dms, algalN, &
           doc, don, dic, fed, fep, zaeros, hum
+      use ice_grid, only: tmask
       use ice_state, only: trcrn
       use ice_flux, only: sss  
       use ice_restart, only:  write_restart_field
@@ -1057,6 +1060,39 @@
          file=__FILE__, line=__LINE__)
 
       diag = .true.
+
+      !-----------------------------------------------------------------
+      ! Zero out tracers over land
+      !-----------------------------------------------------------------
+
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
+      do iblk = 1, nblocks
+         this_block = get_block(blocks_ice(iblk),iblk)         
+         ilo = this_block%ilo
+         ihi = this_block%ihi
+         jlo = this_block%jlo
+         jhi = this_block%jhi
+         do j = jlo, jhi
+         do i = ilo, ihi
+            if (.not. tmask(i,j,iblk)) then
+               if (tr_bgc_N  ) algalN(i,j,:,iblk) = c0
+               if (tr_bgc_C  ) doc   (i,j,:,iblk) = c0
+               if (tr_bgc_C  ) dic   (i,j,:,iblk) = c0
+               if (tr_bgc_Nit) nit   (i,j  ,iblk) = c0
+               if (tr_bgc_Am ) amm   (i,j  ,iblk) = c0
+               if (tr_bgc_Sil) sil   (i,j  ,iblk) = c0
+               if (tr_bgc_hum) hum   (i,j  ,iblk) = c0
+               if (tr_bgc_DMS) dms   (i,j  ,iblk) = c0
+               if (tr_bgc_DMS) dmsp  (i,j  ,iblk) = c0
+               if (tr_bgc_DON) don   (i,j,:,iblk) = c0
+               if (tr_bgc_Fe ) fed   (i,j,:,iblk) = c0
+               if (tr_bgc_Fe ) fep   (i,j,:,iblk) = c0
+               if (solve_zsal) sss   (i,j  ,iblk) = c0
+            endif
+         enddo
+         enddo
+      enddo
+      !$OMP END PARALLEL DO
 
       !-----------------------------------------------------------------
       ! Salinity and extras

--- a/configuration/scripts/tests/comparelog.csh
+++ b/configuration/scripts/tests/comparelog.csh
@@ -55,8 +55,8 @@ if (${filearg} == 1) then
       touch ${test_out}
 
       if (${cicefile} == 1) then
-        cat ${base_data} | grep -A 99999999 "total ice area  (km^2)" | grep -e istep1: -e = | grep -iv "min, max, sum" >&! ${base_out}
-        cat ${test_data} | grep -A 99999999 "total ice area  (km^2)" | grep -e istep1: -e = | grep -iv "min, max, sum" >&! ${test_out}
+        cat ${base_data} | grep -A 99999999 "total ice area  (km^2)" | grep -e istep1: -e = | grep -iv "min, max, sum" | grep -iv "init_vert" | grep -iv "ridge_ice"  >&! ${base_out}
+        cat ${test_data} | grep -A 99999999 "total ice area  (km^2)" | grep -e istep1: -e = | grep -iv "min, max, sum" | grep -iv "init_vert" | grep -iv "ridge_ice"  >&! ${test_out}
       else
         sed -n '/RunningUnitTest/,$p' ${base_data} >! ${base_out}
         sed -n '/RunningUnitTest/,$p' ${test_data} >! ${test_out}

--- a/configuration/scripts/tests/omp_suite.ts
+++ b/configuration/scripts/tests/omp_suite.ts
@@ -8,6 +8,7 @@ smoke          gx3     4x4        alt04,reprosum,run10day
 smoke          gx3     4x4        alt05,reprosum,run10day
 smoke          gx3     8x2        alt06,reprosum,run10day
 smoke          gx3     8x2        bgcz,reprosum,run10day
+smoke          gx1    15x2        reprosum,run10day
 smoke          gx1    15x2        seabedprob,reprosum,run10day
 smoke          gx3    14x2        fsd12,reprosum,run10day
 smoke          gx3    11x2        isotope,reprosum,run10day
@@ -25,25 +26,26 @@ smoke        gbox80   11x3        boxslotcyl,reprosum,run10day
 smoke          gx3     4x2        diag1,reprosum,run10day,cmplogrest              smoke_gx3_8x4_diag1_reprosum_run10day
 smoke          gx3     4x1        diag1,reprosum,run10day,cmplogrest,thread       smoke_gx3_8x4_diag1_reprosum_run10day
 smoke          gx3     8x1        alt01,reprosum,run10day,cmplogrest,thread       smoke_gx3_6x2_alt01_reprosum_run10day
-smoke          gx3    16x1        alt02,reprosum,run10day,cmplogrest,thread       smoke_gx3_8x2_alt02_reprosum_run10day
-smoke          gx3    24x1        alt03,reprosum,run10day,cmplogrest,thread       smoke_gx3_12x2_alt03_droundrobin_reprosum_run10day
-smoke          gx3    24x1        alt04,reprosum,run10day,cmplogrest,thread       smoke_gx3_4x4_alt04_reprosum_run10day
-smoke          gx3    14x1        alt05,reprosum,run10day,cmplogrest,thread       smoke_gx3_4x4_alt05_reprosum_run10day
-smoke          gx3    24x1        alt06,reprosum,run10day,cmplogrest,thread       smoke_gx3_8x2_alt06_reprosum_run10day
-smoke          gx3    12x1        bgcz,reprosum,run10day,cmplogrest,thread        smoke_gx3_8x2_bgcz_reprosum_run10day
-smoke          gx1    28x1        seabedprob,reprosum,run10day,cmplogrest,thread  smoke_gx1_15x2_reprosum_run10day_seabedprob
-smoke          gx3    30x1        fsd12,reprosum,run10day,cmplogrest,thread       smoke_gx3_14x2_fsd12_reprosum_run10day
-smoke          gx3    16x1        isotope,reprosum,run10day,cmplogrest,thread     smoke_gx3_11x2_isotope_reprosum_run10day
-smoke          gx3    28x1        snwitdrdg,snwgrain,icdefault,reprosum,run10day,cmplogrest,thread  smoke_gx3_8x4_icdefault_reprosum_run10day_snwitdrdg_snwgrain
-smoke          gx3    18x1        dynpicard,reprosum,run10day,cmplogrest,thread   smoke_gx3_6x4_dynpicard_reprosum_run10day
-smoke          gx3    20x1        zsal,reprosum,run10day,cmplogrest,thread        smoke_gx3_8x3_reprosum_run10day_zsal
+smoke          gx3     8x1        alt02,reprosum,run10day,cmplogrest,thread       smoke_gx3_8x2_alt02_reprosum_run10day
+smoke          gx3     8x1        alt03,reprosum,run10day,cmplogrest,thread       smoke_gx3_12x2_alt03_droundrobin_reprosum_run10day
+smoke          gx3     8x1        alt04,reprosum,run10day,cmplogrest,thread       smoke_gx3_4x4_alt04_reprosum_run10day
+smoke          gx3     8x1        alt05,reprosum,run10day,cmplogrest,thread       smoke_gx3_4x4_alt05_reprosum_run10day
+smoke          gx3     8x1        alt06,reprosum,run10day,cmplogrest,thread       smoke_gx3_8x2_alt06_reprosum_run10day
+smoke          gx3     8x1        bgcz,reprosum,run10day,cmplogrest,thread        smoke_gx3_8x2_bgcz_reprosum_run10day
+smoke          gx1    18x1        reprosum,run10day,cmplogrest,thread             smoke_gx1_15x2_reprosum_run10day
+smoke          gx1    18x1        seabedprob,reprosum,run10day,cmplogrest,thread  smoke_gx1_15x2_reprosum_run10day_seabedprob
+smoke          gx3     8x1        fsd12,reprosum,run10day,cmplogrest,thread       smoke_gx3_14x2_fsd12_reprosum_run10day
+smoke          gx3     8x1        isotope,reprosum,run10day,cmplogrest,thread     smoke_gx3_11x2_isotope_reprosum_run10day
+smoke          gx3     8x1        snwitdrdg,snwgrain,icdefault,reprosum,run10day,cmplogrest,thread  smoke_gx3_8x4_icdefault_reprosum_run10day_snwitdrdg_snwgrain
+smoke          gx3     8x1        dynpicard,reprosum,run10day,cmplogrest,thread   smoke_gx3_6x4_dynpicard_reprosum_run10day
+smoke          gx3     8x1        zsal,reprosum,run10day,cmplogrest,thread        smoke_gx3_8x3_reprosum_run10day_zsal
 
-smoke        gbox128  20x1        reprosum,run10day,cmplogrest,thread             smoke_gbox128_8x2_reprosum_run10day
-smoke        gbox128  16x1        boxnodyn,reprosum,run10day,cmplogrest,thread    smoke_gbox128_12x2_boxnodyn_reprosum_run10day
-smoke        gbox128  14x1        boxadv,reprosum,run10day,cmplogrest,thread      smoke_gbox128_9x2_boxadv_reprosum_run10day
-smoke        gbox128  24x1        boxrestore,reprosum,run10day,cmplogrest,thread  smoke_gbox128_14x2_boxrestore_reprosum_run10day
-smoke        gbox80   19x1        box2001,reprosum,run10day,cmplogrest,thread     smoke_gbox80_4x5_box2001_reprosum_run10day
-smoke        gbox80    8x4        boxslotcyl,reprosum,run10day,cmplogrest,thread  smoke_gbox80_11x3_boxslotcyl_reprosum_run10day
+smoke        gbox128   8x1        reprosum,run10day,cmplogrest,thread             smoke_gbox128_8x2_reprosum_run10day
+smoke        gbox128   8x1        boxnodyn,reprosum,run10day,cmplogrest,thread    smoke_gbox128_12x2_boxnodyn_reprosum_run10day
+smoke        gbox128   8x1        boxadv,reprosum,run10day,cmplogrest,thread      smoke_gbox128_9x2_boxadv_reprosum_run10day
+smoke        gbox128   8x1        boxrestore,reprosum,run10day,cmplogrest,thread  smoke_gbox128_14x2_boxrestore_reprosum_run10day
+smoke        gbox80    8x1        box2001,reprosum,run10day,cmplogrest,thread     smoke_gbox80_4x5_box2001_reprosum_run10day
+smoke        gbox80    8x1        boxslotcyl,reprosum,run10day,cmplogrest,thread  smoke_gbox80_11x3_boxslotcyl_reprosum_run10day
 
 #gridC
 
@@ -55,6 +57,7 @@ smoke          gx3     4x4        alt04,reprosum,run10day,gridc
 smoke          gx3     4x4        alt05,reprosum,run10day,gridc
 smoke          gx3     8x2        alt06,reprosum,run10day,gridc
 smoke          gx3     8x2        bgcz,reprosum,run10day,gridc
+smoke          gx1    15x2        reprosum,run10day,gridc
 smoke          gx1    15x2        seabedprob,reprosum,run10day,gridc
 smoke          gx3    14x2        fsd12,reprosum,run10day,gridc
 smoke          gx3    11x2        isotope,reprosum,run10day,gridc
@@ -72,25 +75,26 @@ smoke        gbox80   11x3        boxslotcyl,reprosum,run10day,gridc
 smoke          gx3     4x2        diag1,reprosum,run10day,cmplogrest,gridc              smoke_gx3_8x4_gridc_diag1_reprosum_run10day
 smoke          gx3     4x1        diag1,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_8x4_gridc_diag1_reprosum_run10day
 smoke          gx3     8x1        alt01,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_6x2_alt01_gridc_reprosum_run10day
-smoke          gx3    16x1        alt02,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_8x2_alt02_gridc_reprosum_run10day
-smoke          gx3    24x1        alt03,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_12x2_alt03_droundrobin_gridc_reprosum_run10day
-smoke          gx3    24x1        alt04,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_4x4_alt04_gridc_reprosum_run10day
-smoke          gx3    14x1        alt05,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_4x4_alt05_gridc_reprosum_run10day
-smoke          gx3    24x1        alt06,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_8x2_alt06_gridc_reprosum_run10day
-smoke          gx3    12x1        bgcz,reprosum,run10day,cmplogrest,thread,gridc        smoke_gx3_8x2_bgcz_gridc_reprosum_run10day
-smoke          gx1    28x1        seabedprob,reprosum,run10day,cmplogrest,thread,gridc  smoke_gx1_15x2_gridc_reprosum_run10day_seabedprob
-smoke          gx3    30x1        fsd12,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_14x2_fsd12_gridc_reprosum_run10day
-smoke          gx3    16x1        isotope,reprosum,run10day,cmplogrest,thread,gridc     smoke_gx3_11x2_gridc_isotope_reprosum_run10day
-smoke          gx3    28x1        snwitdrdg,snwgrain,icdefault,reprosum,run10day,cmplogrest,thread,gridc  smoke_gx3_8x4_gridc_icdefault_reprosum_run10day_snwitdrdg_snwgrain
-smoke          gx3    18x1        dynpicard,reprosum,run10day,cmplogrest,thread,gridc   smoke_gx3_6x4_dynpicard_gridc_reprosum_run10day
-smoke          gx3    20x1        zsal,reprosum,run10day,cmplogrest,thread,gridc        smoke_gx3_8x3_gridc_reprosum_run10day_zsal
+smoke          gx3     8x1        alt02,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_8x2_alt02_gridc_reprosum_run10day
+smoke          gx3     8x1        alt03,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_12x2_alt03_droundrobin_gridc_reprosum_run10day
+smoke          gx3     8x1        alt04,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_4x4_alt04_gridc_reprosum_run10day
+smoke          gx3     8x1        alt05,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_4x4_alt05_gridc_reprosum_run10day
+smoke          gx3     8x1        alt06,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_8x2_alt06_gridc_reprosum_run10day
+smoke          gx3     8x1        bgcz,reprosum,run10day,cmplogrest,thread,gridc        smoke_gx3_8x2_bgcz_gridc_reprosum_run10day
+smoke          gx1    18x1        reprosum,run10day,cmplogrest,thread,gridc             smoke_gx1_15x2_gridc_reprosum_run10day
+smoke          gx1    18x1        seabedprob,reprosum,run10day,cmplogrest,thread,gridc  smoke_gx1_15x2_gridc_reprosum_run10day_seabedprob
+smoke          gx3     8x1        fsd12,reprosum,run10day,cmplogrest,thread,gridc       smoke_gx3_14x2_fsd12_gridc_reprosum_run10day
+smoke          gx3     8x1        isotope,reprosum,run10day,cmplogrest,thread,gridc     smoke_gx3_11x2_gridc_isotope_reprosum_run10day
+smoke          gx3     8x1        snwitdrdg,snwgrain,icdefault,reprosum,run10day,cmplogrest,thread,gridc  smoke_gx3_8x4_gridc_icdefault_reprosum_run10day_snwitdrdg_snwgrain
+smoke          gx3     8x1        dynpicard,reprosum,run10day,cmplogrest,thread,gridc   smoke_gx3_6x4_dynpicard_gridc_reprosum_run10day
+smoke          gx3     8x1        zsal,reprosum,run10day,cmplogrest,thread,gridc        smoke_gx3_8x3_gridc_reprosum_run10day_zsal
 
-smoke        gbox128  20x1        reprosum,run10day,cmplogrest,thread,gridc             smoke_gbox128_8x2_gridc_reprosum_run10day
-smoke        gbox128  16x1        boxnodyn,reprosum,run10day,cmplogrest,thread,gridc    smoke_gbox128_12x2_boxnodyn_gridc_reprosum_run10day
-smoke        gbox128  14x1        boxadv,reprosum,run10day,cmplogrest,thread,gridc      smoke_gbox128_9x2_boxadv_gridc_reprosum_run10day
-smoke        gbox128  24x1        boxrestore,reprosum,run10day,cmplogrest,thread,gridc  smoke_gbox128_14x2_boxrestore_gridc_reprosum_run10day
-smoke        gbox80   19x1        box2001,reprosum,run10day,cmplogrest,thread,gridc     smoke_gbox80_4x5_box2001_gridc_reprosum_run10day
-smoke        gbox80    8x4        boxslotcyl,reprosum,run10day,cmplogrest,thread,gridc  smoke_gbox80_11x3_boxslotcyl_gridc_reprosum_run10day
+smoke        gbox128   8x1        reprosum,run10day,cmplogrest,thread,gridc             smoke_gbox128_8x2_gridc_reprosum_run10day
+smoke        gbox128   8x1        boxnodyn,reprosum,run10day,cmplogrest,thread,gridc    smoke_gbox128_12x2_boxnodyn_gridc_reprosum_run10day
+smoke        gbox128   8x1        boxadv,reprosum,run10day,cmplogrest,thread,gridc      smoke_gbox128_9x2_boxadv_gridc_reprosum_run10day
+smoke        gbox128   8x1        boxrestore,reprosum,run10day,cmplogrest,thread,gridc  smoke_gbox128_14x2_boxrestore_gridc_reprosum_run10day
+smoke        gbox80    8x1        box2001,reprosum,run10day,cmplogrest,thread,gridc     smoke_gbox80_4x5_box2001_gridc_reprosum_run10day
+smoke        gbox80    8x1        boxslotcyl,reprosum,run10day,cmplogrest,thread,gridc  smoke_gbox80_11x3_boxslotcyl_gridc_reprosum_run10day
 
 #gridCD
 
@@ -102,6 +106,7 @@ smoke          gx3     4x4        alt04,reprosum,run10day,gridcd
 smoke          gx3     4x4        alt05,reprosum,run10day,gridcd
 smoke          gx3     8x2        alt06,reprosum,run10day,gridcd
 smoke          gx3     8x2        bgcz,reprosum,run10day,gridcd
+smoke          gx1    15x2        reprosum,run10day,gridcd
 smoke          gx1    15x2        seabedprob,reprosum,run10day,gridcd
 smoke          gx3    14x2        fsd12,reprosum,run10day,gridcd
 smoke          gx3    11x2        isotope,reprosum,run10day,gridcd
@@ -119,23 +124,24 @@ smoke        gbox80   11x3        boxslotcyl,reprosum,run10day,gridcd
 smoke          gx3     4x2        diag1,reprosum,run10day,cmplogrest,gridcd              smoke_gx3_8x4_gridcd_diag1_reprosum_run10day
 smoke          gx3     4x1        diag1,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_8x4_gridcd_diag1_reprosum_run10day
 smoke          gx3     8x1        alt01,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_6x2_alt01_gridcd_reprosum_run10day
-smoke          gx3    16x1        alt02,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_8x2_alt02_gridcd_reprosum_run10day
-smoke          gx3    24x1        alt03,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_12x2_alt03_droundrobin_gridcd_reprosum_run10day
-smoke          gx3    24x1        alt04,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_4x4_alt04_gridcd_reprosum_run10day
-smoke          gx3    14x1        alt05,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_4x4_alt05_gridcd_reprosum_run10day
-smoke          gx3    24x1        alt06,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_8x2_alt06_gridcd_reprosum_run10day
-smoke          gx3    12x1        bgcz,reprosum,run10day,cmplogrest,thread,gridcd        smoke_gx3_8x2_bgcz_gridcd_reprosum_run10day
-smoke          gx1    28x1        seabedprob,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gx1_15x2_gridcd_reprosum_run10day_seabedprob
-smoke          gx3    30x1        fsd12,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_14x2_fsd12_gridcd_reprosum_run10day
-smoke          gx3    16x1        isotope,reprosum,run10day,cmplogrest,thread,gridcd     smoke_gx3_11x2_gridcd_isotope_reprosum_run10day
-smoke          gx3    28x1        snwitdrdg,snwgrain,icdefault,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gx3_8x4_gridcd_icdefault_reprosum_run10day_snwitdrdg_snwgrain
-smoke          gx3    18x1        dynpicard,reprosum,run10day,cmplogrest,thread,gridcd   smoke_gx3_6x4_dynpicard_gridcd_reprosum_run10day
-smoke          gx3    20x1        zsal,reprosum,run10day,cmplogrest,thread,gridcd        smoke_gx3_8x3_gridcd_reprosum_run10day_zsal
+smoke          gx3     8x1        alt02,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_8x2_alt02_gridcd_reprosum_run10day
+smoke          gx3     8x1        alt03,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_12x2_alt03_droundrobin_gridcd_reprosum_run10day
+smoke          gx3     8x1        alt04,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_4x4_alt04_gridcd_reprosum_run10day
+smoke          gx3     8x1        alt05,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_4x4_alt05_gridcd_reprosum_run10day
+smoke          gx3     8x1        alt06,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_8x2_alt06_gridcd_reprosum_run10day
+smoke          gx3     8x1        bgcz,reprosum,run10day,cmplogrest,thread,gridcd        smoke_gx3_8x2_bgcz_gridcd_reprosum_run10day
+smoke          gx1    18x1        reprosum,run10day,cmplogrest,thread,gridcd             smoke_gx1_15x2_gridcd_reprosum_run10day
+smoke          gx1    18x1        seabedprob,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gx1_15x2_gridcd_reprosum_run10day_seabedprob
+smoke          gx3     8x1        fsd12,reprosum,run10day,cmplogrest,thread,gridcd       smoke_gx3_14x2_fsd12_gridcd_reprosum_run10day
+smoke          gx3     8x1        isotope,reprosum,run10day,cmplogrest,thread,gridcd     smoke_gx3_11x2_gridcd_isotope_reprosum_run10day
+smoke          gx3     8x1        snwitdrdg,snwgrain,icdefault,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gx3_8x4_gridcd_icdefault_reprosum_run10day_snwitdrdg_snwgrain
+smoke          gx3     8x1        dynpicard,reprosum,run10day,cmplogrest,thread,gridcd   smoke_gx3_6x4_dynpicard_gridcd_reprosum_run10day
+smoke          gx3     8x1        zsal,reprosum,run10day,cmplogrest,thread,gridcd        smoke_gx3_8x3_gridcd_reprosum_run10day_zsal
 
-smoke        gbox128  20x1        reprosum,run10day,cmplogrest,thread,gridcd             smoke_gbox128_8x2_gridcd_reprosum_run10day
-smoke        gbox128  16x1        boxnodyn,reprosum,run10day,cmplogrest,thread,gridcd    smoke_gbox128_12x2_boxnodyn_gridcd_reprosum_run10day
-smoke        gbox128  14x1        boxadv,reprosum,run10day,cmplogrest,thread,gridcd      smoke_gbox128_9x2_boxadv_gridcd_reprosum_run10day
-smoke        gbox128  24x1        boxrestore,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gbox128_14x2_boxrestore_gridcd_reprosum_run10day
-smoke        gbox80   19x1        box2001,reprosum,run10day,cmplogrest,thread,gridcd     smoke_gbox80_4x5_box2001_gridcd_reprosum_run10day
-smoke        gbox80    8x4        boxslotcyl,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gbox80_11x3_boxslotcyl_gridcd_reprosum_run10day
+smoke        gbox128   8x1        reprosum,run10day,cmplogrest,thread,gridcd             smoke_gbox128_8x2_gridcd_reprosum_run10day
+smoke        gbox128   8x1        boxnodyn,reprosum,run10day,cmplogrest,thread,gridcd    smoke_gbox128_12x2_boxnodyn_gridcd_reprosum_run10day
+smoke        gbox128   8x1        boxadv,reprosum,run10day,cmplogrest,thread,gridcd      smoke_gbox128_9x2_boxadv_gridcd_reprosum_run10day
+smoke        gbox128   8x1        boxrestore,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gbox128_14x2_boxrestore_gridcd_reprosum_run10day
+smoke        gbox80    8x1        box2001,reprosum,run10day,cmplogrest,thread,gridcd     smoke_gbox80_4x5_box2001_gridcd_reprosum_run10day
+smoke        gbox80    8x1        boxslotcyl,reprosum,run10day,cmplogrest,thread,gridcd  smoke_gbox80_11x3_boxslotcyl_gridcd_reprosum_run10day
 


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix box2001 forcing, restart fields on land, bathymetry default value, omp_suite
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Full test suites run on cheyenne, results as expected
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit except box2001
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [X] Yes, modify omp_suite to better cover different decompositions
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:

These changes should be migrated to main sooner than later.

- Update box2001 so it's bit-for-bit with different blocks/decomps/pe counts.
- Initialize bathymetry values at all gridcells when bathymetry_format='default' and use_bathymetry=.false.
- Update comparelog to exclude extraneous icepack output
- Zero out certain non-zero fields when writing restart files to deal with land-block-elimination and restart file comparisons
- Update omp_suite to test different decomps when testing different threads