### PR TITLE
New deformationsC_T subroutine for more consistent calculation

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -113,7 +113,7 @@
       use ice_dyn_evp_1d, only: ice_dyn_evp_1d_copyin, ice_dyn_evp_1d_kernel, &
           ice_dyn_evp_1d_copyout
       use ice_dyn_shared, only: evp_algorithm, stack_fields, unstack_fields, &
-          DminTarea, visc_method, deformations, deformations_T, deformations_T2, &
+          DminTarea, visc_method, deformations, deformationsC_T, deformationsCD_T, &
           strain_rates_U, &
           dyn_haloUpdate
 
@@ -126,8 +126,7 @@
          ksub           , & ! subcycle step
          iblk           , & ! block index
          ilo,ihi,jlo,jhi, & ! beginning and end of physical domain
-         i, j, ij,        & ! local indices
-         deform_option
+         i, j, ij           ! local indices
 
       integer (kind=int_kind), dimension(max_blocks) :: &
          icellt   , & ! no. of cells where icetmask = 1
@@ -225,8 +224,6 @@
          first_time = .true. ! first time logical
 
       character(len=*), parameter :: subname = '(evp)'
-
-      deform_option = 1
 
       call ice_timer_start(timer_dynamics) ! dynamics
 
@@ -858,22 +855,7 @@
                   !-----------------------------------------------------------------
                   if (ksub == ndte) then
 
-                     if (deform_option == 1) then
-
-                     call deformations_T (nx_block          , ny_block           , &
-                                          icellt      (iblk),                      &
-                                          indxti    (:,iblk), indxtj     (:,iblk), &
-                                          uvelE   (:,:,iblk), vvelE    (:,:,iblk), &
-                                          uvelN   (:,:,iblk), vvelN    (:,:,iblk), &
-                                          dxN     (:,:,iblk), dyE      (:,:,iblk), &
-                                          dxT     (:,:,iblk), dyT      (:,:,iblk), &
-                                          tarear  (:,:,iblk),                      &
-                                          shear   (:,:,iblk), divu     (:,:,iblk), &
-                                          rdg_conv(:,:,iblk), rdg_shear(:,:,iblk))
-                     
-                     elseif (deform_option == 2) then
-
-                     call deformations_T2 (nx_block          , ny_block           , &
+                     call deformationsC_T (nx_block          , ny_block          , &
                                           icellt      (iblk),                      &
                                           indxti    (:,iblk), indxtj     (:,iblk), &
                                           uvelE   (:,:,iblk), vvelE    (:,:,iblk), &
@@ -885,8 +867,6 @@
                                           shear   (:,:,iblk), divu     (:,:,iblk), &
                                           rdg_conv(:,:,iblk), rdg_shear(:,:,iblk))
                      
-                     endif
-
                   endif
                enddo
                !$OMP END PARALLEL DO
@@ -1020,16 +1000,16 @@
                   ! on last subcycle, save quantities for mechanical redistribution
                   !-----------------------------------------------------------------
                   if (ksub == ndte) then
-                     call deformations_T (nx_block          , ny_block           , &
-                                          icellt      (iblk),                      &
-                                          indxti    (:,iblk), indxtj     (:,iblk), &
-                                          uvelE   (:,:,iblk), vvelE    (:,:,iblk), &
-                                          uvelN   (:,:,iblk), vvelN    (:,:,iblk), &
-                                          dxN     (:,:,iblk), dyE      (:,:,iblk), &
-                                          dxT     (:,:,iblk), dyT      (:,:,iblk), &
-                                          tarear  (:,:,iblk),                      &
-                                          shear   (:,:,iblk), divu     (:,:,iblk), &
-                                          rdg_conv(:,:,iblk), rdg_shear(:,:,iblk))
+                     call deformationsCD_T (nx_block          , ny_block           , &
+                                            icellt      (iblk),                      &
+                                            indxti    (:,iblk), indxtj     (:,iblk), &
+                                            uvelE   (:,:,iblk), vvelE    (:,:,iblk), &
+                                            uvelN   (:,:,iblk), vvelN    (:,:,iblk), &
+                                            dxN     (:,:,iblk), dyE      (:,:,iblk), &
+                                            dxT     (:,:,iblk), dyT      (:,:,iblk), &
+                                            tarear  (:,:,iblk),                      &
+                                            shear   (:,:,iblk), divu     (:,:,iblk), &
+                                            rdg_conv(:,:,iblk), rdg_shear(:,:,iblk))
                   endif
                enddo
                !$OMP END PARALLEL DO

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -27,7 +27,7 @@
                 principal_stress, init_dyn, dyn_prep1, dyn_prep2, dyn_finish, &
                 seabed_stress_factor_LKD, seabed_stress_factor_prob, &
                 alloc_dyn_shared, &
-                deformations, deformations_T, deformations_T2, &
+                deformations, deformationsC_T, deformationsCD_T, &
                 strain_rates, strain_rates_T, strain_rates_U, &
                 visc_replpress, &
                 dyn_haloUpdate, &
@@ -1733,16 +1733,16 @@
 ! author: JF Lemieux, ECCC
 ! Nov 2021
 
-      subroutine deformations_T (nx_block,   ny_block,   &
-                                 icellt,                 &
-                                 indxti,     indxtj,     &
-                                 uvelE,      vvelE,      &
-                                 uvelN,      vvelN,      &
-                                 dxN,        dyE,        &
-                                 dxT,        dyT,        &
-                                 tarear,                 &
-                                 shear,      divu,       &
-                                 rdg_conv,   rdg_shear )
+      subroutine deformationsCD_T (nx_block,   ny_block,   &
+                                   icellt,                 &
+                                   indxti,     indxtj,     &
+                                   uvelE,      vvelE,      &
+                                   uvelN,      vvelN,      &
+                                   dxN,        dyE,        &
+                                   dxT,        dyT,        &
+                                   tarear,                 &
+                                   shear,      divu,       &
+                                   rdg_conv,   rdg_shear )
 
       use ice_constants, only: p5
 
@@ -1820,7 +1820,7 @@
 
       enddo                     ! ij
 
-      end subroutine deformations_T
+    end subroutine deformationsCD_T
 
 
 !=======================================================================
@@ -1829,17 +1829,17 @@
 ! author: JF Lemieux, ECCC
 ! Nov 2021
 
-      subroutine deformations_T2 (nx_block,   ny_block,  &
-                                 icellt,                 &
-                                 indxti,     indxtj,     &
-                                 uvelE,      vvelE,      &
-                                 uvelN,      vvelN,      &
-                                 dxN,        dyE,        &
-                                 dxT,        dyT,        &
-                                 tarear,     uarea,      &
-                                 shearU,                 &
-                                 shear,      divu,       &
-                                 rdg_conv,   rdg_shear )
+    subroutine deformationsC_T (nx_block,   ny_block,   &
+                                icellt,                 &
+                                indxti,     indxtj,     &
+                                uvelE,      vvelE,      &
+                                uvelN,      vvelN,      &
+                                dxN,        dyE,        &
+                                dxT,        dyT,        &
+                                tarear,     uarea,      &
+                                shearU,                 &
+                                shear,      divu,       &
+                                rdg_conv,   rdg_shear )
 
       use ice_constants, only: p5
 
@@ -1911,7 +1911,6 @@
          !-----------------------------------------------------------------
          ! deformations for mechanical redistribution
          !-----------------------------------------------------------------
-
          
          shearTsqr = (shearU(i  ,j  )**2 * uarea(i  ,j  )  &
                     + shearU(i  ,j-1)**2 * uarea(i  ,j-1)  &
@@ -1932,7 +1931,7 @@
 
       enddo                     ! ij
 
-      end subroutine deformations_T2
+    end subroutine deformationsC_T
 
 !=======================================================================
 ! Compute strain rates

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -27,7 +27,7 @@
                 principal_stress, init_dyn, dyn_prep1, dyn_prep2, dyn_finish, &
                 seabed_stress_factor_LKD, seabed_stress_factor_prob, &
                 alloc_dyn_shared, &
-                deformations, deformations_T, &
+                deformations, deformations_T, deformations_T2, &
                 strain_rates, strain_rates_T, strain_rates_U, &
                 visc_replpress, &
                 dyn_haloUpdate, &
@@ -1821,6 +1821,118 @@
       enddo                     ! ij
 
       end subroutine deformations_T
+
+
+!=======================================================================
+! Compute deformations for mechanical redistribution at T point
+!
+! author: JF Lemieux, ECCC
+! Nov 2021
+
+      subroutine deformations_T2 (nx_block,   ny_block,  &
+                                 icellt,                 &
+                                 indxti,     indxtj,     &
+                                 uvelE,      vvelE,      &
+                                 uvelN,      vvelN,      &
+                                 dxN,        dyE,        &
+                                 dxT,        dyT,        &
+                                 tarear,     uarea,      &
+                                 shearU,                 &
+                                 shear,      divu,       &
+                                 rdg_conv,   rdg_shear )
+
+      use ice_constants, only: p5
+
+      integer (kind=int_kind), intent(in) :: &
+         nx_block, ny_block, & ! block dimensions
+         icellt                ! no. of cells where icetmask = 1
+
+      integer (kind=int_kind), dimension (nx_block*ny_block), intent(in) :: &
+         indxti   , & ! compressed index in i-direction
+         indxtj       ! compressed index in j-direction
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
+         uvelE    , & ! x-component of velocity (m/s) at the E point
+         vvelE    , & ! y-component of velocity (m/s) at the N point
+         uvelN    , & ! x-component of velocity (m/s) at the E point
+         vvelN    , & ! y-component of velocity (m/s) at the N point
+         dxN      , & ! width of N-cell through the middle (m)
+         dyE      , & ! height of E-cell through the middle (m)
+         dxT      , & ! width of T-cell through the middle (m)
+         dyT      , & ! height of T-cell through the middle (m)
+         tarear   , & ! 1/tarea
+         uarea    , & ! area of u cell
+         shearU       ! shearU
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(inout) :: &
+         shear    , & ! strain rate II component (1/s)
+         divu     , & ! strain rate I component, velocity divergence (1/s)
+         rdg_conv , & ! convergence term for ridging (1/s)
+         rdg_shear    ! shear term for ridging (1/s)
+
+      ! local variables
+
+      integer (kind=int_kind) :: &
+         i, j, ij
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block) :: &
+        divT      , & ! divergence at T point
+        tensionT  , & ! tension at T point
+        shearT    , & ! shear at T point
+        DeltaT        ! delt at T point
+
+      real (kind=dbl_kind) :: &
+        tmp       , & ! useful combination
+        shearTsqr     ! strain rates squared at T point
+
+      character(len=*), parameter :: subname = '(deformations_T2)'
+
+      !-----------------------------------------------------------------
+      ! strain rates
+      ! NOTE these are actually strain rates * area  (m^2/s)
+      !-----------------------------------------------------------------
+
+      call strain_rates_T (nx_block   ,   ny_block   , &
+                           icellt     ,                &
+                           indxti(:)  , indxtj  (:)  , &
+                           uvelE (:,:), vvelE   (:,:), &
+                           uvelN (:,:), vvelN   (:,:), &
+                           dxN   (:,:), dyE     (:,:), &
+                           dxT   (:,:), dyT     (:,:), &
+                           divT  (:,:), tensionT(:,:), &
+                           shearT(:,:), DeltaT  (:,:)  )
+
+      ! DeltaT is calc by strain_rates_T but replaced by calculation below.
+
+      do ij = 1, icellt
+         i = indxti(ij)
+         j = indxtj(ij)
+
+         !-----------------------------------------------------------------
+         ! deformations for mechanical redistribution
+         !-----------------------------------------------------------------
+
+         
+         shearTsqr = (shearU(i  ,j  )**2 * uarea(i  ,j  )  &
+                    + shearU(i  ,j-1)**2 * uarea(i  ,j-1)  &
+                    + shearU(i-1,j-1)**2 * uarea(i-1,j-1)  &
+                    + shearU(i-1,j  )**2 * uarea(i-1,j  )) &
+                    / (uarea(i,j)+uarea(i,j-1)+uarea(i-1,j-1)+uarea(i-1,j))
+
+         DeltaT(i,j) = sqrt(divT(i,j)**2 + e_factor*(tensionT(i,j)**2 + shearTsqr))
+
+         divu(i,j) = divT(i,j) * tarear(i,j)
+         tmp = DeltaT(i,j) * tarear(i,j)
+         rdg_conv(i,j)  = -min(divu(i,j),c0)
+         rdg_shear(i,j) = p5*(tmp-abs(divu(i,j)))
+
+         ! diagnostic only...maybe we dont want to use shearTsqr here????
+         ! shear = sqrt(tension**2 + shearing**2)
+         shear(i,j) = tarear(i,j)*sqrt( tensionT(i,j)**2 + shearT(i,j)**2 )
+
+      enddo                     ! ij
+
+      end subroutine deformations_T2
 
 !=======================================================================
 ! Compute strain rates


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    deformationsC_T uses DeltaT consistent with the rest of the C grid code. I have kept the previous approach (renamed deformationsCD_T) for the CD grid. This will need to be revisited later. 
- [x] Developer(s): 
@JFLemieux73 
- [x] Suggest PR reviewers from list in the column to the right.
  @apcraig 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    I tested one day gx3 run: BFB for B grid evp. It slightly changes the answer for the C grid (as expected).
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:
