### PR TITLE
More machine updates, Cori, Onyx, Narwhal, Hera

### DIFF
--- a/cicecore/cicedynB/infrastructure/comm/mpi/ice_boundary.F90
+++ b/cicecore/cicedynB/infrastructure/comm/mpi/ice_boundary.F90
@@ -225,8 +225,8 @@ contains
 
    !*** store some block info to fill haloes properly
    call ice_distributionGet(dist, numLocalBlocks=halo%numLocalBlocks)
+   allocate(halo%blockGlobalID(halo%numLocalBlocks))
    if (halo%numLocalBlocks > 0) then
-      allocate(halo%blockGlobalID(halo%numLocalBlocks))
       call ice_distributionGet(dist, blockGlobalID=halo%blockGlobalID)
    endif
 

--- a/cicecore/cicedynB/infrastructure/ice_read_write.F90
+++ b/cicecore/cicedynB/infrastructure/ice_read_write.F90
@@ -1058,6 +1058,7 @@
 
           status = nf90_open(filename, NF90_NOWRITE, fid)
           if (status /= nf90_noerr) then
+             !write(nu_diag,*) subname,' NF90_STRERROR = ',trim(nf90_strerror(status))
              call abort_ice(subname//' ERROR: Cannot open '//trim(filename), &
                 file=__FILE__, line=__LINE__)
           endif

--- a/configuration/scripts/machines/Macros.narwhal_aocc
+++ b/configuration/scripts/machines/Macros.narwhal_aocc
@@ -3,7 +3,7 @@
 #==============================================================================
 
 CPP        := ftn -E
-CPPDEFS    := -DNO_R16 -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 ${ICE_CPPDEFS}
 CFLAGS     := -c -O2
 
 FIXEDFLAGS := -ffixed-form

--- a/configuration/scripts/machines/Macros.narwhal_cray
+++ b/configuration/scripts/machines/Macros.narwhal_cray
@@ -3,7 +3,7 @@
 #==============================================================================
 
 CPP        := ftn -e P
-CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 ${ICE_CPPDEFS}
 CFLAGS     := -c -O2
 
 FIXEDFLAGS := -132

--- a/configuration/scripts/machines/env.cori_intel
+++ b/configuration/scripts/machines/env.cori_intel
@@ -13,42 +13,45 @@ module unload PrgEnv-cray
 module unload PrgEnv-gnu
 module unload PrgEnv-intel
 module unload PrgEnv-pgi
-module load PrgEnv-intel/6.0.5
+module load PrgEnv-intel/6.0.10
 
 module unload intel
-module load intel/19.0.3.199
+module load intel/19.1.2.254
 module unload gcc
-module load gcc/8.2.0
+module load gcc/11.2.0
 
 module unload cray-mpich
 module unload cray-mpich-abi
-module load cray-mpich/7.7.6
+module load cray-mpich/7.7.19
 
 module unload cray-hdf5
 module unload cray-hdf5-parallel
 module unload cray-netcdf
 module unload cray-netcdf-hdf5parallel
 module unload cray-parallel-netcdf
-module load cray-netcdf/4.6.3.2
+module load cray-netcdf/4.8.1.1
 
 module unload cray-libsci
 
 module unload craype
-module load craype/2.6.2
+module load craype/2.7.10
 
 setenv NETCDF_PATH ${NETCDF_DIR}
+
+endif
+
+setenv HDF5_USE_FILE_LOCKING FALSE
+
 setenv OMP_PROC_BIND true
 setenv OMP_PLACES threads
 setenv OMP_STACKSIZE 32M
 limit coredumpsize unlimited
 limit stacksize unlimited
 
-endif
-
 setenv ICE_MACHINE_MACHNAME cori
 setenv ICE_MACHINE_MACHINFO "Cray XC40 Xeon E5-2698v3 Haswell"
 setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "ifort 19.0.3.199 20190206, gcc/8.2.0, cray-mpich/7.7.6, netcdf/4.6.3.2"
+setenv ICE_MACHINE_ENVINFO "ifort 19.1.2.254 20200623, gcc/11.2.0, cray-mpich/7.7.19, netcdf/4.8.1.1"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $SCRATCH/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /project/projectdirs/ccsm1/cice-consortium/

--- a/configuration/scripts/machines/env.hera_intel
+++ b/configuration/scripts/machines/env.hera_intel
@@ -15,11 +15,11 @@ module load impi/2018.0.4
 module load netcdf/4.7.0
 #module list
 
-# May be needed for OpenMP memory
-#setenv OMP_STACKSIZE 64M
-
 endif
  
+# May be needed for OpenMP memory
+setenv OMP_STACKSIZE 64M
+
 setenv ICE_MACHINE_MACHNAME hera
 setenv ICE_MACHINE_MACHINFO "Cray CS500 Intel SkyLake 2.4GHz, Infiniband HDR"
 setenv ICE_MACHINE_ENVNAME intel


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    More machine updates, mostly for cori
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    More tests are running and passing on the various machines, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#a3592a7c7d1290da6af3050a78af0a7a77500dce
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

- Update cori modules, add "setenv HDF5_USE_FILE_LOCKING FALSE" to fix issues reading netcdf-4 format file (default wave_spec_file) from non-scratch file systems.  See https://docs.nersc.gov/development/libraries/hdf5/
- Update ice_boundary implementation to allocate(0) for halo%blockGlobalID.  Some compilers are now complaining if the memory is accessed but never allocated.
- Add -DNO_R16 for narwhal cray
- Add "setenv OMP_STACKSIZE 64M" for hera

